### PR TITLE
Fix failing rubocop check

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -49,7 +49,7 @@ Style/Alias:
 Style/BeginBlock:
   Enabled: true
 
-Naming/UncommunicativeMethodParamName:
+Naming/MethodParameterName:
   AllowedNames:
     - cn
 


### PR DESCRIPTION
```
$ bundle exec rubocop
.rubocop.relaxed.yml: Metrics/LineLength has the wrong namespace - should be Layout
Error: The `Naming/UncommunicativeMethodParamName` cop has been renamed to `Naming/MethodParameterName`.
(obsolete configuration found in .rubocop.yml, please update it)
```