### PR TITLE
Fix autocompletion generation when sub-command has hyphens

### DIFF
--- a/lib/clamp/completer/templates/zsh.sh.erb
+++ b/lib/clamp/completer/templates/zsh.sh.erb
@@ -1,26 +1,27 @@
 #compdef <%= progname %>
 
+<% command_name = invocation_path.join('_').gsub("-","_") %>
 <%- iterator.recurse do |invocation_path, command_class| -%>
 <%- if command_class.has_subcommands? -%>
-_<%= invocation_path.join('_').gsub("-", "_") %>_subcommands() {
+_<%= command_name %>_subcommands() {
   local subcommands=( <%= command_class.recognised_subcommands.map { |sc| "'#{sc.names.first}:#{sc.description.gsub(/'\$\\/, '\\\1') }'" }.join(' ') %> )
   _describe 'subcommands' subcommands && return 0
   return 1
 }
 
 <%- else -%>
-_<%= invocation_path.join('_').gsub("-","_") %>_subcommands() {
+_<%= command_name %>_subcommands() {
   return 1
 }
 
 <%- end -%>
 
-_<%= invocation_path.join('_').gsub("-","_") %>() {
+_<%= command_name %>() {
   local curcontext="$curcontext" state state_descr line expl
   local ret=1
 
   _arguments -C : \
-    '1:subcommands:_<%= invocation_path.join('_') %>_subcommands' \
+    '1:subcommands:_<%= command_name %>_subcommands' \
     <%- command_class.recognised_options.each do |opt| -%>
       <%- if opt.type == :flag -%>
         <%- if opt.long_switch.include?('[no-]') -%>
@@ -84,7 +85,7 @@ _<%= invocation_path.join('_').gsub("-","_") %>() {
     '*::options:->options' && return 0
 
   case "$state" in
-    command) _<%= invocation_path.join('_') %>_subcommands && return 0 ;;
+    command) _<%= command_name %>_subcommands && return 0 ;;
     options)
       local command="${line[1]}"
       curcontext="${curcontext%:*:*}:<%= invocation_path.join('-') %>-${command}"

--- a/lib/clamp/completer/templates/zsh.sh.erb
+++ b/lib/clamp/completer/templates/zsh.sh.erb
@@ -1,7 +1,7 @@
 #compdef <%= progname %>
 
-<% command_name = invocation_path.join('_').gsub("-","_") %>
 <%- iterator.recurse do |invocation_path, command_class| -%>
+<% command_name = invocation_path.join('_').gsub("-","_") %>
 <%- if command_class.has_subcommands? -%>
 _<%= command_name %>_subcommands() {
   local subcommands=( <%= command_class.recognised_subcommands.map { |sc| "'#{sc.names.first}:#{sc.description.gsub(/'\$\\/, '\\\1') }'" }.join(' ') %> )
@@ -88,10 +88,10 @@ _<%= command_name %>() {
     command) _<%= command_name %>_subcommands && return 0 ;;
     options)
       local command="${line[1]}"
-      curcontext="${curcontext%:*:*}:<%= invocation_path.join('-') %>-${command}"
+      curcontext="${curcontext%:*:*}:<%= command_name %>-${command}"
 
       line=(${line:1})
-      local completion_func="_<%= invocation_path.join('_') %>_${command//-/_}"
+      local completion_func="_<%= command_name %>_${command//-/_}"
       _call_function ret "${completion_func}" && return ret
 
       _message "a completion function is not defined for ${command}"

--- a/spec/clamp/completer_spec.rb
+++ b/spec/clamp/completer_spec.rb
@@ -1,5 +1,124 @@
+require 'clamp'
+
 RSpec.describe Clamp::Completer do
+  include OutputCapture
+  extend CommandFactory
+
   it "has a version number" do
     expect(Clamp::Completer::VERSION).not_to be nil
+  end
+
+  given_command("cmd") do
+    subcommand "complete", "shell autocompletions", Clamp::Completer.new(self)
+    subcommand "render-profile", "Command with hyphen" do
+      def execute
+        puts "Command with hyphen"
+      end
+    end
+  end
+
+  it "generates zsh autocompletion" do
+    command.run(%w[complete zsh])
+    # expect(stdout).to be("render-profile")
+    expect(stdout).to eq(%{#compdef rspec
+
+
+_rspec_complete_subcommands() {
+  return 1
+}
+
+
+_rspec_complete() {
+  local curcontext="$curcontext" state state_descr line expl
+  local ret=1
+
+  _arguments -C : \\
+    '1:subcommands:_rspec_complete_subcommands' \\
+            {-h,--help}'[print help]' \\
+    '*::options:->options' && return 0
+
+  case "$state" in
+    command) _rspec_complete_subcommands && return 0 ;;
+    options)
+      local command="${line[1]}"
+      curcontext="${curcontext%:*:*}:rspec_complete-${command}"
+
+      line=(${line:1})
+      local completion_func="_rspec_complete_${command//-/_}"
+      _call_function ret "${completion_func}" && return ret
+
+      _message "a completion function is not defined for ${command}"
+      return 1
+    ;;
+  esac
+}
+
+
+_rspec_render_profile_subcommands() {
+  return 1
+}
+
+
+_rspec_render_profile() {
+  local curcontext="$curcontext" state state_descr line expl
+  local ret=1
+
+  _arguments -C : \\
+    '1:subcommands:_rspec_render_profile_subcommands' \\
+            {-h,--help}'[print help]' \\
+    '*::options:->options' && return 0
+
+  case "$state" in
+    command) _rspec_render_profile_subcommands && return 0 ;;
+    options)
+      local command="${line[1]}"
+      curcontext="${curcontext%:*:*}:rspec_render_profile-${command}"
+
+      line=(${line:1})
+      local completion_func="_rspec_render_profile_${command//-/_}"
+      _call_function ret "${completion_func}" && return ret
+
+      _message "a completion function is not defined for ${command}"
+      return 1
+    ;;
+  esac
+}
+
+
+_rspec_subcommands() {
+  local subcommands=( 'complete:shell autocompletions' 'render-profile:Command with hyphen' )
+  _describe 'subcommands' subcommands && return 0
+  return 1
+}
+
+
+_rspec() {
+  local curcontext="$curcontext" state state_descr line expl
+  local ret=1
+
+  _arguments -C : \\
+    '1:subcommands:_rspec_subcommands' \\
+            {-h,--help}'[print help]' \\
+    '*::options:->options' && return 0
+
+  case "$state" in
+    command) _rspec_subcommands && return 0 ;;
+    options)
+      local command="${line[1]}"
+      curcontext="${curcontext%:*:*}:rspec-${command}"
+
+      line=(${line:1})
+      local completion_func="_rspec_${command//-/_}"
+      _call_function ret "${completion_func}" && return ret
+
+      _message "a completion function is not defined for ${command}"
+      return 1
+    ;;
+  esac
+}
+
+
+compdef _rspec rspec
+})
   end
 end

--- a/spec/clamp/completer_spec.rb
+++ b/spec/clamp/completer_spec.rb
@@ -19,7 +19,6 @@ RSpec.describe Clamp::Completer do
 
   it "generates zsh autocompletion" do
     command.run(%w[complete zsh])
-    # expect(stdout).to be("render-profile")
     expect(stdout).to eq(%{#compdef rspec
 
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,38 @@
 require "bundler/setup"
 require "clamp/completer"
 
+module CommandFactory
+  def given_command(name, &block)
+    let(:command_class) do
+      Class.new(Clamp::Command, &block)
+    end
+    let(:command) do
+      command_class.new(name)
+    end
+  end
+end
+module OutputCapture
+  def self.included(target)
+    target.before do
+      $stdout = @out = StringIO.new
+      $stderr = @err = StringIO.new
+    end
+
+    target.after do
+      $stdout = STDOUT
+      $stderr = STDERR
+    end
+  end
+
+  def stdout
+    @out.string
+  end
+
+  def stderr
+    @err.string
+  end
+end
+
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = ".rspec_status"


### PR DESCRIPTION
Noticed this behaviour in Scooter when trying to type something like the following which returns an error,

```sh
> scooter render-app _arguments:463: command not found: _scooter_render-app_subcommands
```
Testing this was hard, so just wrote a simple test to ensure generation of autocompletion works. However, testing the autocompletion is more complicated and I'm not attempting it for now. For now, tested by using my branch in Scooter and verifying the autocompletion. 